### PR TITLE
SVG card rendering capability

### DIFF
--- a/main.py
+++ b/main.py
@@ -38,17 +38,19 @@ class ContentNotFound(Exception): pass
 
 def render_code_output(cell,lang='python', render_md=render_md):
     res = []
+    def _join_strip_list(lst): return ''.join(strip_list(lst))
     if len(cell['outputs'])==0: ''
     for output in cell['outputs']:
         if output['output_type'] in ('execute_result', 'display_data'):
             data = output['data']
-            if 'text/html' in data.keys(): res.append(NotStr(''.join(data['text/html'])))
+            if 'text/html' in data.keys(): 
+                res.append(NotStr(_join_strip_list(data['text/html'])))
             elif 'text/markdown' in data.keys(): 
-                res.append(NotStr(''.join(strip_list(data['text/markdown'][1:-1]))))
+                res.append(NotStr(render_md(_join_strip_list(data['text/markdown'][1:-1]))))
             elif 'text/plain' in data.keys(): 
-                res.append(''.join(strip_list(data['text/plain'])))
+                res.append(_join_strip_list(data['text/plain']))
         if output['output_type'] == 'stream':
-            res.append(''.join(strip_list(output['text'])))
+            res.append(_join_strip_list(output['text']))
     if res: return Div(*res, container=Pre)
 
 # The following functions are three content loading. They are cached in

--- a/main.py
+++ b/main.py
@@ -40,16 +40,16 @@ def render_code_output(cell,lang='python', render_md=render_md):
     res = []
     if len(cell['outputs'])==0: ''
     for output in cell['outputs']:
-        print(output['output_type'])
-        if output['output_type'] == 'execute_result':
+        if output['output_type'] in ('execute_result', 'display_data'):
             data = output['data']
-            if 'text/markdown' in data.keys(): 
+            if 'text/html' in data.keys(): res.append(NotStr(''.join(data['text/html'])))
+            elif 'text/markdown' in data.keys(): 
                 res.append(NotStr(''.join(strip_list(data['text/markdown'][1:-1]))))
             elif 'text/plain' in data.keys(): 
                 res.append(''.join(strip_list(data['text/plain'])))
         if output['output_type'] == 'stream':
             res.append(''.join(strip_list(output['text'])))
-    if res: return render_md(*res, container=Pre)
+    if res: return Div(*res, container=Pre)
 
 # The following functions are three content loading. They are cached in
 # memory to boost the speed of the site. In production at a minumum the

--- a/posts/2025/2025-01-deck-of-cards.ipynb
+++ b/posts/2025/2025-01-deck-of-cards.ipynb
@@ -30,7 +30,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": 1,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -44,7 +44,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 2,
    "metadata": {},
    "outputs": [
     {
@@ -80,7 +80,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 3,
    "metadata": {},
    "outputs": [
     {
@@ -247,7 +247,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 4,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -266,7 +266,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 5,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -277,7 +277,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 6,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -298,7 +298,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 7,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -307,7 +307,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 8,
    "metadata": {},
    "outputs": [
     {
@@ -426,7 +426,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 9,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -447,7 +447,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 10,
    "metadata": {},
    "outputs": [
     {
@@ -601,7 +601,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 11,
    "metadata": {},
    "outputs": [
     {
@@ -748,7 +748,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": 12,
    "metadata": {},
    "outputs": [
     {
@@ -923,7 +923,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": 13,
    "metadata": {},
    "outputs": [
     {
@@ -1094,18 +1094,13 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "![asdasd]('http://127.0.0.1:5001/public/cards/FJH.svg')\n"
+    "![asdasd](http://127.0.0.1:5001/public/cards/FJH.svg)\n"
    ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": []
   }
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": ".venv",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -1119,7 +1114,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.12.6"
+   "version": "3.12.8"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Here is the result of our pairing on SVG card rendering for the blog.

This is the rendering function I am using for mine.  The logic will need to change for your blog, but this may have more cell types that may want to include in the future (ie png/jpg)

```python
def render_code_output(cell, lang='python', pygments=False, wrapper=Footer):
    if not cell.outputs: return ''
    
    def render_output(out):
        otype = out['output_type']
        if otype == 'stream':
            txt = ansi2html(''.join(out["text"]))
            xtra = '' if out['name']=='stdout' else "class='stderr'"
            is_err = '<span class' in txt
            return Safe(f"<pre {xtra}><code class='{'nohighlight hljs' if is_err else ''}'>{txt}</code></pre>")
        elif otype in ('display_data','execute_result'):
            data = out['data']
            _g = lambda t: ''.join(data[t]) if t in data else None
            if d := _g('text/html'): return Safe(apply_classes(d))
            if d := _g('application/javascript'): return Safe(f'<script>{d}</script>')
            if d := _g('text/markdown'): return render_md(d)
            if d := _g('text/latex'): return Safe(f'<div class="math">${d}$</div>')
            if d := _g('image/jpeg'): return Safe(f'<img src="data:image/jpeg;base64,{d}"/>')
            if d := _g('image/png'): return Safe(f'<img src="data:image/png;base64,{d}"/>')
            if d := _g('text/plain'): return escape(d)
            if d := _g('image/svg+xml'): return Safe(d)
        return ''
    
    res = Div(*map(render_output, cell.outputs))
    if res: return wrapper(res)
```